### PR TITLE
修复CheckScriptErrorTool:当静态检查的脚本中含有class_name定义的全局类时，静态检查因为全局类名重定义而始终失败的问题

### DIFF
--- a/addons/agent/tools/tools_nodes/check_script_error_tool.gd
+++ b/addons/agent/tools/tools_nodes/check_script_error_tool.gd
@@ -119,6 +119,7 @@ func _run_external_syntax_check(path: String, log_file_path: String) -> Dictiona
 		"result_text": text,
 	}
 
+
 func _run_static_parse_check(path: String) -> Dictionary:
 	var source_code := FileAccess.get_file_as_string(path)
 	if FileAccess.get_open_error() != OK:
@@ -127,17 +128,23 @@ func _run_static_parse_check(path: String) -> Dictionary:
 			"phase": "static",
 			"result_text": "静态检查失败：无法读取脚本内容。"
 		}
-
-	var script := GDScript.new()
-	script.source_code = source_code
+	var script:GDScript=ResourceLoader.load(path,"GDScript",ResourceLoader.CACHE_MODE_IGNORE_DEEP)
+	if script==null:
+		return {
+			"ok": false,
+			"phase": "static",
+			"result_text": "静态检查失败：无法装载脚本。"
+		}
+	
 	var reload_error := script.reload()
-
+	
 	return {
 		"ok": reload_error == OK,
 		"phase": "static",
 		"error_code": reload_error,
 		"result_text": "代码没有静态解析错误" if reload_error == OK else "静态解析失败：%s" % error_string(reload_error)
 	}
+
 
 func _read_log_file_result(log_file_path: String) -> Dictionary:
 	if not FileAccess.file_exists(log_file_path):


### PR DESCRIPTION
<img width="793" height="477" alt="ce5729c07c13dc1de57c0e251f11d8db" src="https://github.com/user-attachments/assets/e0d39865-b951-4544-8453-f23abc3e3f7a" />
