### PR TITLE
修复CheckScriptErrorTool:当静态检查的脚本中含有class_name定义的全局类时，静态检查因为全局类名重定义而始终失败的问题

### DIFF
--- a/addons/agent/tools/tools_nodes/check_script_error_tool.gd
+++ b/addons/agent/tools/tools_nodes/check_script_error_tool.gd
@@ -127,11 +127,14 @@ func _run_static_parse_check(path: String) -> Dictionary:
 			"phase": "static",
 			"result_text": "静态检查失败：无法读取脚本内容。"
 		}
-
-	var script := GDScript.new()
-	script.source_code = source_code
+	var script:GDScript=ResourceLoader.load(path,"GDScript",ResourceLoader.CACHE_MODE_IGNORE_DEEP)
+	if script==null:
+		return {
+			"ok": false,
+			"phase": "static",
+			"result_text": "静态检查失败：无法装载脚本。"
+		}
 	var reload_error := script.reload()
-
 	return {
 		"ok": reload_error == OK,
 		"phase": "static",


### PR DESCRIPTION
<img width="793" height="477" alt="ce5729c07c13dc1de57c0e251f11d8db" src="https://github.com/user-attachments/assets/5d5cf58b-e0b8-4bb4-be96-2f18944958e9" />
