### PR TITLE
feat: 添加openai兼容协议v2支持

### DIFF
--- a/addons/agent/scripts/chat_wrapper/openai_chat.gd
+++ b/addons/agent/scripts/chat_wrapper/openai_chat.gd
@@ -91,6 +91,9 @@ func post_message(messages: Array[Dictionary]):
 	elif url.ends_with("/v3"):
 		# 豆包等使用 v3，只添加 /chat/completions
 		url += "/chat/completions"
+	elif url.ends_with("/v2"):
+		# 讯飞 codeplan 使用v2
+		url += "/chat/completions"
 	elif url.ends_with("/v1"):
 		# 标准 OpenAI，只添加 /chat/completions
 		url += "/chat/completions"


### PR DESCRIPTION
部分平台使用v2协议，需要添加v2协议url的拼接代码